### PR TITLE
DOO 719: Socket Hangup Issue

### DIFF
--- a/lib/http.ts
+++ b/lib/http.ts
@@ -66,6 +66,12 @@ export const makeRequest = async (self: Self, request: Request, httpReboundError
   self.logger.debug('body before request: ', JSON.stringify(body));
   self.logger.debug('headers before request: ', JSON.stringify(headers));
 
+  self.emit('trace:graphql-request', {
+    url,
+    headers,
+    body,
+  });
+
   const reboundErrorCodes = getHttpReboundErrorCodes(httpReboundErrorCodes);
   try {
     const response = await axios.post(url, body, {

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -7,20 +7,22 @@ import jsonata from 'jsonata';
 const HTTP_ERROR_CODE_REBOUND = new Set([408, 423, 429, 500, 502, 503, 504]);
 const AXIOS_TIMEOUT_ERROR = 'ECONNABORTED';
 
+const MAX_SOCKETS = process.env.MAX_SOCKETS ? parseInt(process.env.MAX_SOCKETS) : 3;
+
 const httpAgent = new http.Agent({
-  keepAlive: true,        // Enable connection reuse
-  keepAliveMsecs: 30000,  // Keep idle connections alive for 30 seconds
-  maxSockets: 3,          // Limit concurrent connections to 3
-  maxFreeSockets: 3,      // Keep up to 3 idle connections ready for reuse
-  timeout: 30000,         // Socket timeout (30s)
+  keepAlive: true,              // Enable connection reuse
+  keepAliveMsecs: 30000,        // Keep idle connections alive for 30 seconds
+  maxSockets: MAX_SOCKETS,      // Limit concurrent connections to 3
+  maxFreeSockets: MAX_SOCKETS,  // Keep up to 3 idle connections ready for reuse
+  timeout: 5000,                // Socket timeout (5s)
 });
 
 const httpsAgent = new https.Agent({
-  keepAlive: true,        // Enable connection reuse
-  keepAliveMsecs: 30000,  // Keep idle connections alive for 30 seconds
-  maxSockets: 3,          // Limit concurrent connections to 3
-  maxFreeSockets: 3,      // Keep up to 3 idle connections ready for reuse
-  timeout: 30000,         // Socket timeout (30s)
+  keepAlive: true,              // Enable connection reuse
+  keepAliveMsecs: 30000,        // Keep idle connections alive for 30 seconds
+  maxSockets: MAX_SOCKETS,      // Limit concurrent connections to 3
+  maxFreeSockets: MAX_SOCKETS,  // Keep up to 3 idle connections ready for reuse
+  timeout: 5000,                // Socket timeout (5s)
 });
 
 export function populateAuthHeaders(auth: Auth, self: Self, bearerToken: string, headers?: Array<Headers>,): Array<Headers> {


### PR DESCRIPTION
## Background
https://linear.app/doohickeyai/issue/DOO-719/graphql-component-fix-socket-timeout-in-axios-issue

## Changes
Node `httpAgent` and `httpsAgent` are configured and passed to Axios for reuse across all requests.

These agents are configured to allow reuse of existing sockets, while limiting the number of sockets in use to 3 (or the value of the environment variable `MAX_SOCKETS`.

The configuration breaks down as follows:
- `keepAlive: true` - keep sockets alive to be reused again - prevents repeatedly having to open a new socket
- `keepAliveMsecs` - how long to keep connections alive if they are not being used
- `maxSockets` - the max number of sockets to have in use
- `maxFreeSockets` - the max number of sockets to keep open while not in use

## Additional Idea (not implemented)
Automatically retry on socket hang up errors.


```js
const isSocketHangupError = e instanceof AxiosError && e.message && e.message === 'socket hang up';

if (
  (enableRebound && e instanceof AxiosError && e?.response && reboundErrorCodes.has(e?.response?.status)) ||
  (enableRebound && (e instanceof AxiosError && e.code === AXIOS_TIMEOUT_ERROR || e.message.includes('DNS lookup timeout'))) ||
  (enableRebound && isSocketHangupError) // <-- this condition is new
) {
```