### PR TITLE
DOO 719: Explicit False Value for KeepAlive

### DIFF
--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,9 +1,19 @@
+import http from 'http';
+import https from 'https';
 import axios, { AxiosError } from 'axios';
 import { Auth, Self, AuthTypes, Headers, Request, GlobalLogContext, ErrorHandlingConfig } from './types/global';
 import jsonata from 'jsonata';
 
 const HTTP_ERROR_CODE_REBOUND = new Set([408, 423, 429, 500, 502, 503, 504]);
 const AXIOS_TIMEOUT_ERROR = 'ECONNABORTED';
+
+const httpAgent = new http.Agent({
+  keepAlive: false,
+});
+
+const httpsAgent = new https.Agent({
+  keepAlive: false,
+});
 
 export function populateAuthHeaders(auth: Auth, self: Self, bearerToken: string, headers?: Array<Headers>,): Array<Headers> {
   const newHeaders = [];
@@ -50,7 +60,7 @@ export const makeRequest = async (self: Self, request: Request, httpReboundError
 
   const reboundErrorCodes = getHttpReboundErrorCodes(httpReboundErrorCodes);
   try {
-    const response = await axios.post(url, body, { timeout, headers });
+    const response = await axios.post(url, body, { timeout, headers, httpAgent, httpsAgent });
     const { data, status } = response;
 
     self.logger.debug('GraphQL response data: ', JSON.stringify(data));


### PR DESCRIPTION
Sets the http agent `keepAlive` value to explicit `false` with the goal of avoiding long running sockets that eventually get closed by the server.